### PR TITLE
Fix outdated launcher check

### DIFF
--- a/src/handlers/event/analyze_logs/issues.rs
+++ b/src/handlers/event/analyze_logs/issues.rs
@@ -195,7 +195,7 @@ async fn outdated_launcher(log: &str, data: &Data) -> Result<Issue> {
 
 	let octocrab = &data.octocrab;
 	let log_version = &captures[1];
-	let log_version_parts = semver_split(&log_version);
+	let log_version_parts = semver_split(log_version);
 
 	let latest_version = if let Some(storage) = &data.storage {
 		if let Ok(version) = storage.launcher_version().await {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,7 +12,6 @@ pub fn embed_author_from_user(user: &User) -> CreateEmbedAuthor {
 pub fn semver_split(version: &str) -> Vec<u32> {
 	version
 		.split('.')
-		.map(|s| s.parse().ok())
-		.flatten()
+		.filter_map(|s| s.parse().ok())
 		.collect::<Vec<u32>>()
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,3 +8,11 @@ pub fn embed_author_from_user(user: &User) -> CreateEmbedAuthor {
 			.unwrap_or_else(|| user.default_avatar_url()),
 	)
 }
+
+pub fn semver_split(version: &str) -> Vec<u32> {
+	version
+		.split('.')
+		.map(|s| s.parse().ok())
+		.flatten()
+		.collect::<Vec<u32>>()
+}


### PR DESCRIPTION
This didn't work before because it only supported x.y.z versions. Now always considers a version outdated if it uses the old version scheme.
Also, I assume < was doing a lexicographical comparison which infamously breaks on multi-digit numbers. 10.0 would be considered a smaller version number than 9.0 for example due to it starting with 1 and being compared the same way as letters. 