### PR TITLE
improvement: reword message when no issues were found automatically

### DIFF
--- a/src/handlers/event/analyze_logs/mod.rs
+++ b/src/handlers/event/analyze_logs/mod.rs
@@ -49,7 +49,7 @@ pub async fn handle(ctx: &Context, message: &Message, data: &Data) -> Result<()>
 		if issues.is_empty() {
 			e = e
 				.color(Colors::Green)
-				.description("The automatic check didn't reveal any issues, but it's possible that some issues went unnoticed. Please wait for a volunteer to assist you.");
+				.description("The automatic check didn't reveal any issues, but it's possible that some issues went undetected. Please wait for a volunteer to assist you.");
 		} else {
 			e = e.color(Colors::Red);
 

--- a/src/handlers/event/analyze_logs/mod.rs
+++ b/src/handlers/event/analyze_logs/mod.rs
@@ -49,7 +49,7 @@ pub async fn handle(ctx: &Context, message: &Message, data: &Data) -> Result<()>
 		if issues.is_empty() {
 			e = e
 				.color(Colors::Green)
-				.description("No issues found automatically");
+				.description("The automatic check didn't reveal any issues, but it's possible that some issues went unnoticed. Please wait for a volunteer to assist you.");
 		} else {
 			e = e.color(Colors::Red);
 


### PR DESCRIPTION
So a lot of people seem to come to the Prism Community server to get help, they send their logs, then see that the bot says "No issue found automatically", and do one of these things:
1. Do nothing (aka wait for a person to come help them, which is the correct action)
2. Yell at/tell the bot that it is wrong (which the bot cannot process)
3. reply to the bot after they find the solution (which again, the bot cannot process)
4. Get a little impatient when a person does come and help them :(

So to resolve this I propose to reword what is said when the bot cannot find any issue automatically within the log.

Now, instead of simply saying "No issue found automatically", the bot will now reply with "The automatic check didn't reveal any issues, but it's possible that some issues went unnoticed. Please wait for a volunteer to assist you." This tells the person to be patient as the bot couldn't find any of the problem it has listed despite there being a problem.

Credits to the following people who joined in on the discussion and iterating on it to how it is now (displayed in images because I don't want to @ people here)

![image](https://github.com/user-attachments/assets/c4ccd15c-fccc-452e-b3d2-e95b83cab001)
![image](https://github.com/user-attachments/assets/22ee1785-b679-4b64-b741-d6276655e4ea)
![image](https://github.com/user-attachments/assets/d1f86085-4877-47c2-8a5c-2cfd8ab2ba73)
![image](https://github.com/user-attachments/assets/0b0c2e3e-0382-48f3-92cb-d5737be71d11)
![image](https://github.com/user-attachments/assets/e087c7e2-39c4-4fd8-bb94-5140e92242da)
![image](https://github.com/user-attachments/assets/a3388d97-83d8-46e3-9b52-fe033c78aa1c)
![image](https://github.com/user-attachments/assets/4f6bff09-8cb7-4dea-8d89-8d481056a82a)

Extra shoutout to maskers for running a copy of Refraction on his bot so we can see what the changes look like in Discord
![image](https://github.com/user-attachments/assets/04273e38-a8d8-465c-b6e4-07c6be1cacda)

@ZekeZDev if you see this, I'm sorry we made such a big fuss over literal punctuation in a Discord bot 👍

last minute edits: @RandomPrimary2004 and @HurricanePootis wanted mentions so uh here you go ig?