### PR TITLE
Fix: Add detection for 32 bit java on -Xms

### DIFF
--- a/src/handlers/event/analyze_logs/issues.rs
+++ b/src/handlers/event/analyze_logs/issues.rs
@@ -371,6 +371,7 @@ fn java_32_bit(log: &str) -> Issue {
 
 	let found = log.contains("Could not reserve enough space for ")
 		|| log.contains("Invalid maximum heap size: ");
+		|| log.contains("Invalid initial heap size: ");
 	found.then_some(issue)
 }
 

--- a/src/handlers/event/analyze_logs/issues.rs
+++ b/src/handlers/event/analyze_logs/issues.rs
@@ -370,7 +370,7 @@ fn java_32_bit(log: &str) -> Issue {
 	);
 
 	let found = log.contains("Could not reserve enough space for ")
-		|| log.contains("Invalid maximum heap size: ");
+		|| log.contains("Invalid maximum heap size: ")
 		|| log.contains("Invalid initial heap size: ");
 	found.then_some(issue)
 }


### PR DESCRIPTION
Before it was only checking -Xmx, this also checks -Xms