### PR TITLE
update `/tag java` wording

### DIFF
--- a/tags/java.md
+++ b/tags/java.md
@@ -3,4 +3,4 @@ title: Java Instructions
 color: orange
 ---
 
-As of 9.0, Prism Launcher will automatically download and configure Java for the version of Minecraft you are using. The instructions to manually setup and install Java can be found [here](https://prismlauncher.org/wiki/getting-started/installing-java/).
+As of 9.0, Prism Launcher can automatically download and configure Java for the version of Minecraft you are using. The instructions can be found [here](https://prismlauncher.org/wiki/getting-started/installing-java/).


### PR DESCRIPTION
i think this tag should be mostly aimed at people who want to just let prism handle java, and the previous wording wasn't very helpful at telling them how to do it