### PR TITLE
allow newlines in `/say`

### DIFF
--- a/src/commands/general/say.rs
+++ b/src/commands/general/say.rs
@@ -16,6 +16,7 @@ pub async fn say(
 	#[description = "the message content"] content: String,
 ) -> Result<(), Error> {
 	let channel = ctx.channel_id();
+	let content = content.replace("\\n", "\n");
 	let message = channel.say(ctx, &content).await?;
 	ctx.say("I said what you said!").await?;
 


### PR DESCRIPTION
running `/say content:a\nb` will now result in refraction saying
```
a
b
```
`.say` would prob be a better way to implement this but this is a one line change and i'm lazy