### PR TITLE
minor issue detection improvements

### DIFF
--- a/src/handlers/event/analyze_logs/issues.rs
+++ b/src/handlers/event/analyze_logs/issues.rs
@@ -457,10 +457,9 @@ fn linux_openal(log: &str) -> Issue {
 	let issue = (
 		"Missing .alsoftrc".to_string(),
 		"OpenAL is likely missing the configuration file.
-		To fix this, create a file named `.alsoftrc` in your home directory with the following content:
+		To fix this, create a file named `.alsoftrc` in your home directory by running this command in your terminal:
 		```
-drivers=alsa
-hrtf=true```"
+echo -e \"drivers=alsa\\nhrtf=true\" > ~/.alsoftrc```"
 			.to_string(),
 	);
 


### PR DESCRIPTION
- there's been quite a few people struggling to create a `.alsoftrc` file in support channels, running one command has to be simpler
- the proxy instructions would still work for prism 10.0.0