### PR TITLE
fix: support patch releases

### DIFF
--- a/src/handlers/event/analyze_logs/issues.rs
+++ b/src/handlers/event/analyze_logs/issues.rs
@@ -247,10 +247,13 @@ async fn outdated_launcher(log: &str, data: &Data) -> Result<Issue> {
 	};
 	let latest_version_parts = semver_split(&latest_version);
 
-	if log_version_parts.len() != 2
+	if log_version_parts.len() != 3
 		|| log_version_parts[0] < latest_version_parts[0]
 		|| (log_version_parts[0] == latest_version_parts[0]
 			&& log_version_parts[1] < latest_version_parts[1])
+		|| (log_version_parts[0] == latest_version_parts[0]
+			&& log_version_parts[1] == latest_version_parts[1]
+			&& log_version_parts[2] < latest_version_parts[2])
 	{
 		let issue = if log_version_parts[0] < 8 {
 			(


### PR DESCRIPTION
Avoids the "version is 10.0.0 and newest is 10.0.0" bug, it will come back if we switch back to two version numbers.